### PR TITLE
pass in context on all client methods

### DIFF
--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -12,13 +12,13 @@ func (a *Auth) Token() *TokenAuth {
 	return &TokenAuth{c: a.c}
 }
 
-func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
+func (c *TokenAuth) Create(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -29,13 +29,13 @@ func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
-func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
+func (c *TokenAuth) CreateOrphan(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create-orphan")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -46,13 +46,13 @@ func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
-func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*Secret, error) {
+func (c *TokenAuth) CreateWithRole(ctx context.Context, opts *TokenCreateRequest, roleName string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create/"+roleName)
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -63,7 +63,7 @@ func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*
 	return ParseSecret(resp.Body)
 }
 
-func (c *TokenAuth) Lookup(token string) (*Secret, error) {
+func (c *TokenAuth) Lookup(ctx context.Context, token string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -71,7 +71,7 @@ func (c *TokenAuth) Lookup(token string) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -82,7 +82,7 @@ func (c *TokenAuth) Lookup(token string) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
-func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
+func (c *TokenAuth) LookupAccessor(ctx context.Context, accessor string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -90,7 +90,7 @@ func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -101,10 +101,10 @@ func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
-func (c *TokenAuth) LookupSelf() (*Secret, error) {
+func (c *TokenAuth) LookupSelf(ctx context.Context) (*Secret, error) {
 	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -115,7 +115,7 @@ func (c *TokenAuth) LookupSelf() (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
-func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
+func (c *TokenAuth) Renew(ctx context.Context, token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token":     token,
@@ -124,7 +124,7 @@ func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -135,7 +135,7 @@ func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
-func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
+func (c *TokenAuth) RenewSelf(ctx context.Context, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 
 	body := map[string]interface{}{"increment": increment}
@@ -143,7 +143,7 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -156,7 +156,7 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 
 // RenewTokenAsSelf behaves like renew-self, but authenticates using a provided
 // token instead of the token attached to the client.
-func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, error) {
+func (c *TokenAuth) RenewTokenAsSelf(ctx context.Context, token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 	r.ClientToken = token
 
@@ -165,7 +165,7 @@ func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, erro
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -178,7 +178,7 @@ func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, erro
 
 // RevokeAccessor revokes a token associated with the given accessor
 // along with all the child tokens.
-func (c *TokenAuth) RevokeAccessor(accessor string) error {
+func (c *TokenAuth) RevokeAccessor(ctx context.Context, accessor string) error {
 	r := c.c.NewRequest("POST", "/v1/auth/token/revoke-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -186,7 +186,7 @@ func (c *TokenAuth) RevokeAccessor(accessor string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -199,7 +199,7 @@ func (c *TokenAuth) RevokeAccessor(accessor string) error {
 
 // RevokeOrphan revokes a token without revoking the tree underneath it (so
 // child tokens are orphaned rather than revoked)
-func (c *TokenAuth) RevokeOrphan(token string) error {
+func (c *TokenAuth) RevokeOrphan(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-orphan")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -207,7 +207,7 @@ func (c *TokenAuth) RevokeOrphan(token string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -221,10 +221,10 @@ func (c *TokenAuth) RevokeOrphan(token string) error {
 // RevokeSelf revokes the token making the call. The `token` parameter is kept
 // for backwards compatibility but is ignored; only the client's set token has
 // an effect.
-func (c *TokenAuth) RevokeSelf(token string) error {
+func (c *TokenAuth) RevokeSelf(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -238,7 +238,7 @@ func (c *TokenAuth) RevokeSelf(token string) error {
 // RevokeTree is the "normal" revoke operation that revokes the given token and
 // the entire tree underneath -- all of its child tokens, their child tokens,
 // etc.
-func (c *TokenAuth) RevokeTree(token string) error {
+func (c *TokenAuth) RevokeTree(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -246,7 +246,7 @@ func (c *TokenAuth) RevokeTree(token string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/help.go
+++ b/api/help.go
@@ -6,11 +6,11 @@ import (
 )
 
 // Help reads the help information for the given path.
-func (c *Client) Help(path string) (*Help, error) {
+func (c *Client) Help(ctx context.Context, path string) (*Help, error) {
 	r := c.NewRequest("GET", fmt.Sprintf("/v1/%s", path))
 	r.Params.Add("help", "1")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -25,13 +25,13 @@ func (c *Client) SSHWithMountPoint(mountPoint string) *SSH {
 }
 
 // Credential invokes the SSH backend API to create a credential to establish an SSH session.
-func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, error) {
+func (c *SSH) Credential(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/creds/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -44,13 +44,13 @@ func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, err
 
 // SignKey signs the given public key and returns a signed public key to pass
 // along with the SSH request.
-func (c *SSH) SignKey(role string, data map[string]interface{}) (*Secret, error) {
+func (c *SSH) SignKey(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/sign/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -198,7 +198,7 @@ func (c *Client) SSHHelperWithMountPoint(mountPoint string) *SSHHelper {
 // OTP matches the echo request message, instead of searching an entry for the OTP,
 // an echo response message is returned. This feature is used by ssh-helper to verify if
 // its configured correctly.
-func (c *SSHHelper) Verify(otp string) (*SSHVerifyResponse, error) {
+func (c *SSHHelper) Verify(ctx context.Context, otp string) (*SSHVerifyResponse, error) {
 	data := map[string]interface{}{
 		"otp": otp,
 	}
@@ -208,7 +208,7 @@ func (c *SSHHelper) Verify(otp string) (*SSHVerifyResponse, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func (c *Sys) AuditHash(path string, input string) (string, error) {
+func (c *Sys) AuditHash(ctx context.Context, path string, input string) (string, error) {
 	body := map[string]interface{}{
 		"input": input,
 	}
@@ -18,7 +18,7 @@ func (c *Sys) AuditHash(path string, input string) (string, error) {
 		return "", err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -46,10 +46,10 @@ func (c *Sys) AuditHash(path string, input string) (string, error) {
 	return hashStr, nil
 }
 
-func (c *Sys) ListAudit() (map[string]*Audit, error) {
+func (c *Sys) ListAudit(ctx context.Context) (map[string]*Audit, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/audit")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 
@@ -77,21 +77,21 @@ func (c *Sys) ListAudit() (map[string]*Audit, error) {
 
 // DEPRECATED: Use EnableAuditWithOptions instead
 func (c *Sys) EnableAudit(
-	path string, auditType string, desc string, opts map[string]string) error {
-	return c.EnableAuditWithOptions(path, &EnableAuditOptions{
+	ctx context.Context, path string, auditType string, desc string, opts map[string]string) error {
+	return c.EnableAuditWithOptions(ctx, path, &EnableAuditOptions{
 		Type:        auditType,
 		Description: desc,
 		Options:     opts,
 	})
 }
 
-func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) error {
+func (c *Sys) EnableAuditWithOptions(ctx context.Context, path string, options *EnableAuditOptions) error {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/sys/audit/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 
@@ -103,10 +103,10 @@ func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) e
 	return nil
 }
 
-func (c *Sys) DisableAudit(path string) error {
+func (c *Sys) DisableAudit(ctx context.Context, path string) error {
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/audit/%s", path))
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 

--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -8,10 +8,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func (c *Sys) ListAuth() (map[string]*AuthMount, error) {
+func (c *Sys) ListAuth(ctx context.Context) (map[string]*AuthMount, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/auth")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -37,20 +37,20 @@ func (c *Sys) ListAuth() (map[string]*AuthMount, error) {
 }
 
 // DEPRECATED: Use EnableAuthWithOptions instead
-func (c *Sys) EnableAuth(path, authType, desc string) error {
-	return c.EnableAuthWithOptions(path, &EnableAuthOptions{
+func (c *Sys) EnableAuth(ctx context.Context, path, authType, desc string) error {
+	return c.EnableAuthWithOptions(ctx, path, &EnableAuthOptions{
 		Type:        authType,
 		Description: desc,
 	})
 }
 
-func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) error {
+func (c *Sys) EnableAuthWithOptions(ctx context.Context, path string, options *EnableAuthOptions) error {
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/auth/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -61,10 +61,10 @@ func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) err
 	return nil
 }
 
-func (c *Sys) DisableAuth(path string) error {
+func (c *Sys) DisableAuth(ctx context.Context, path string) error {
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/auth/%s", path))
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -8,11 +8,11 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func (c *Sys) CapabilitiesSelf(path string) ([]string, error) {
-	return c.Capabilities(c.c.Token(), path)
+func (c *Sys) CapabilitiesSelf(ctx context.Context, path string) ([]string, error) {
+	return c.Capabilities(ctx, c.c.Token(), path)
 }
 
-func (c *Sys) Capabilities(token, path string) ([]string, error) {
+func (c *Sys) Capabilities(ctx context.Context, token, path string) ([]string, error) {
 	body := map[string]string{
 		"token": token,
 		"path":  path,
@@ -28,7 +28,7 @@ func (c *Sys) Capabilities(token, path string) ([]string, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -7,10 +7,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func (c *Sys) CORSStatus() (*CORSResponse, error) {
+func (c *Sys) CORSStatus(ctx context.Context) (*CORSResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/config/cors")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -35,13 +35,13 @@ func (c *Sys) CORSStatus() (*CORSResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) ConfigureCORS(req *CORSRequest) (*CORSResponse, error) {
+func (c *Sys) ConfigureCORS(ctx context.Context, req *CORSRequest) (*CORSResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/config/cors")
 	if err := r.SetJSONBody(req); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -66,10 +66,10 @@ func (c *Sys) ConfigureCORS(req *CORSRequest) (*CORSResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) DisableCORS() (*CORSResponse, error) {
+func (c *Sys) DisableCORS(ctx context.Context) (*CORSResponse, error) {
 	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -2,18 +2,18 @@ package api
 
 import "context"
 
-func (c *Sys) GenerateRootStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/generate-root/attempt")
+func (c *Sys) GenerateRootStatus(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommon(ctx, "/v1/sys/generate-root/attempt")
 }
 
-func (c *Sys) GenerateDROperationTokenStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+func (c *Sys) GenerateDROperationTokenStatus(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommon(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
 }
 
-func (c *Sys) generateRootStatusCommon(path string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) generateRootStatusCommon(ctx context.Context, path string) (*GenerateRootStatusResponse, error) {
 	r := c.c.NewRequest("GET", path)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -26,15 +26,15 @@ func (c *Sys) generateRootStatusCommon(path string) (*GenerateRootStatusResponse
 	return &result, err
 }
 
-func (c *Sys) GenerateRootInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/generate-root/attempt", otp, pgpKey)
+func (c *Sys) GenerateRootInit(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommon(ctx, "/v1/sys/generate-root/attempt", otp, pgpKey)
 }
 
-func (c *Sys) GenerateDROperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
+func (c *Sys) GenerateDROperationTokenInit(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommon(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
 }
 
-func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) generateRootInitCommon(ctx context.Context, path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
 	body := map[string]interface{}{
 		"otp":     otp,
 		"pgp_key": pgpKey,
@@ -45,7 +45,7 @@ func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootSta
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -58,18 +58,18 @@ func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootSta
 	return &result, err
 }
 
-func (c *Sys) GenerateRootCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/generate-root/attempt")
+func (c *Sys) GenerateRootCancel(ctx context.Context) error {
+	return c.generateRootCancelCommon(ctx, "/v1/sys/generate-root/attempt")
 }
 
-func (c *Sys) GenerateDROperationTokenCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+func (c *Sys) GenerateDROperationTokenCancel(ctx context.Context) error {
+	return c.generateRootCancelCommon(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
 }
 
-func (c *Sys) generateRootCancelCommon(path string) error {
+func (c *Sys) generateRootCancelCommon(ctx context.Context, path string) error {
 	r := c.c.NewRequest("DELETE", path)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -78,15 +78,15 @@ func (c *Sys) generateRootCancelCommon(path string) error {
 	return err
 }
 
-func (c *Sys) GenerateRootUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/generate-root/update", shard, nonce)
+func (c *Sys) GenerateRootUpdate(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommon(ctx, "/v1/sys/generate-root/update", shard, nonce)
 }
 
-func (c *Sys) GenerateDROperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
+func (c *Sys) GenerateDROperationTokenUpdate(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommon(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
 }
 
-func (c *Sys) generateRootUpdateCommon(path, shard, nonce string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) generateRootUpdateCommon(ctx context.Context, path, shard, nonce string) (*GenerateRootStatusResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -97,7 +97,7 @@ func (c *Sys) generateRootUpdateCommon(path, shard, nonce string) (*GenerateRoot
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -2,7 +2,7 @@ package api
 
 import "context"
 
-func (c *Sys) Health() (*HealthResponse, error) {
+func (c *Sys) Health(ctx context.Context) (*HealthResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/health")
 	// If the code is 400 or above it will automatically turn into an error,
 	// but the sys/health API defaults to returning 5xx when not sealed or
@@ -13,7 +13,7 @@ func (c *Sys) Health() (*HealthResponse, error) {
 	r.Params.Add("drsecondarycode", "299")
 	r.Params.Add("performancestandbycode", "299")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -2,10 +2,10 @@ package api
 
 import "context"
 
-func (c *Sys) InitStatus() (bool, error) {
+func (c *Sys) InitStatus(ctx context.Context) (bool, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/init")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -18,13 +18,13 @@ func (c *Sys) InitStatus() (bool, error) {
 	return result.Initialized, err
 }
 
-func (c *Sys) Init(opts *InitRequest) (*InitResponse, error) {
+func (c *Sys) Init(ctx context.Context, opts *InitRequest) (*InitResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/init")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -2,10 +2,10 @@ package api
 
 import "context"
 
-func (c *Sys) Leader() (*LeaderResponse, error) {
+func (c *Sys) Leader(ctx context.Context) (*LeaderResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/leader")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 )
 
-func (c *Sys) Renew(id string, increment int) (*Secret, error) {
+func (c *Sys) Renew(ctx context.Context, id string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/renew")
 
 	body := map[string]interface{}{
@@ -16,7 +16,7 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -27,10 +27,10 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
-func (c *Sys) Revoke(id string) error {
+func (c *Sys) Revoke(ctx context.Context, id string) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke/"+id)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -39,10 +39,10 @@ func (c *Sys) Revoke(id string) error {
 	return err
 }
 
-func (c *Sys) RevokePrefix(id string) error {
+func (c *Sys) RevokePrefix(ctx context.Context, id string) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -51,10 +51,10 @@ func (c *Sys) RevokePrefix(id string) error {
 	return err
 }
 
-func (c *Sys) RevokeForce(id string) error {
+func (c *Sys) RevokeForce(ctx context.Context, id string) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -63,7 +63,7 @@ func (c *Sys) RevokeForce(id string) error {
 	return err
 }
 
-func (c *Sys) RevokeWithOptions(opts *RevokeOptions) error {
+func (c *Sys) RevokeWithOptions(ctx context.Context, opts *RevokeOptions) error {
 	if opts == nil {
 		return errors.New("nil options provided")
 	}
@@ -88,7 +88,7 @@ func (c *Sys) RevokeWithOptions(opts *RevokeOptions) error {
 		}
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -8,10 +8,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func (c *Sys) ListMounts() (map[string]*MountOutput, error) {
+func (c *Sys) ListMounts(ctx context.Context) (map[string]*MountOutput, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/mounts")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -36,13 +36,13 @@ func (c *Sys) ListMounts() (map[string]*MountOutput, error) {
 	return mounts, nil
 }
 
-func (c *Sys) Mount(path string, mountInfo *MountInput) error {
+func (c *Sys) Mount(ctx context.Context, path string, mountInfo *MountInput) error {
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s", path))
 	if err := r.SetJSONBody(mountInfo); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -53,10 +53,10 @@ func (c *Sys) Mount(path string, mountInfo *MountInput) error {
 	return nil
 }
 
-func (c *Sys) Unmount(path string) error {
+func (c *Sys) Unmount(ctx context.Context, path string) error {
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/mounts/%s", path))
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -65,7 +65,7 @@ func (c *Sys) Unmount(path string) error {
 	return err
 }
 
-func (c *Sys) Remount(from, to string) error {
+func (c *Sys) Remount(ctx context.Context, from, to string) error {
 	body := map[string]interface{}{
 		"from": from,
 		"to":   to,
@@ -76,7 +76,7 @@ func (c *Sys) Remount(from, to string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -85,13 +85,13 @@ func (c *Sys) Remount(from, to string) error {
 	return err
 }
 
-func (c *Sys) TuneMount(path string, config MountConfigInput) error {
+func (c *Sys) TuneMount(ctx context.Context, path string, config MountConfigInput) error {
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 	if err := r.SetJSONBody(config); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -100,10 +100,10 @@ func (c *Sys) TuneMount(path string, config MountConfigInput) error {
 	return err
 }
 
-func (c *Sys) MountConfig(path string) (*MountConfigOutput, error) {
+func (c *Sys) MountConfig(ctx context.Context, path string) (*MountConfigOutput, error) {
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -30,7 +30,7 @@ type ListPluginsResponse struct {
 
 // ListPlugins lists all plugins in the catalog and returns their names as a
 // list of strings.
-func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
+func (c *Sys) ListPlugins(ctx context.Context, i *ListPluginsInput) (*ListPluginsResponse, error) {
 	path := ""
 	method := ""
 	if i.Type == consts.PluginTypeUnknown {
@@ -49,7 +49,7 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 		req.Params.Set("list", "true")
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil && resp == nil {
@@ -143,11 +143,11 @@ type GetPluginResponse struct {
 }
 
 // GetPlugin retrieves information about the plugin.
-func (c *Sys) GetPlugin(i *GetPluginInput) (*GetPluginResponse, error) {
+func (c *Sys) GetPlugin(ctx context.Context, i *GetPluginInput) (*GetPluginResponse, error) {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodGet, path)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil {
@@ -184,7 +184,7 @@ type RegisterPluginInput struct {
 }
 
 // RegisterPlugin registers the plugin with the given information.
-func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
+func (c *Sys) RegisterPlugin(ctx context.Context, i *RegisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodPut, path)
 
@@ -192,7 +192,7 @@ func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err == nil {
@@ -212,11 +212,11 @@ type DeregisterPluginInput struct {
 
 // DeregisterPlugin removes the plugin with the given name from the plugin
 // catalog.
-func (c *Sys) DeregisterPlugin(i *DeregisterPluginInput) error {
+func (c *Sys) DeregisterPlugin(ctx context.Context, i *DeregisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodDelete, path)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err == nil {

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -8,14 +8,14 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func (c *Sys) ListPolicies() ([]string, error) {
+func (c *Sys) ListPolicies(ctx context.Context) ([]string, error) {
 	r := c.c.NewRequest("LIST", "/v1/sys/policies/acl")
 	// Set this for broader compatibility, but we use LIST above to be able to
 	// handle the wrapping lookup function
 	r.Method = "GET"
 	r.Params.Set("list", "true")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -40,10 +40,10 @@ func (c *Sys) ListPolicies() ([]string, error) {
 	return result, err
 }
 
-func (c *Sys) GetPolicy(name string) (string, error) {
+func (c *Sys) GetPolicy(ctx context.Context, name string) (string, error) {
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil {
@@ -71,7 +71,7 @@ func (c *Sys) GetPolicy(name string) (string, error) {
 	return "", fmt.Errorf("no policy found in response")
 }
 
-func (c *Sys) PutPolicy(name, rules string) error {
+func (c *Sys) PutPolicy(ctx context.Context, name, rules string) error {
 	body := map[string]string{
 		"policy": rules,
 	}
@@ -81,7 +81,7 @@ func (c *Sys) PutPolicy(name, rules string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -92,10 +92,10 @@ func (c *Sys) PutPolicy(name, rules string) error {
 	return nil
 }
 
-func (c *Sys) DeletePolicy(name string) error {
+func (c *Sys) DeletePolicy(ctx context.Context, name string) error {
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -7,10 +7,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
+func (c *Sys) RekeyStatus(ctx context.Context) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -23,10 +23,10 @@ func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
+func (c *Sys) RekeyRecoveryKeyStatus(ctx context.Context) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/init")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -39,10 +39,10 @@ func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) RekeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
+func (c *Sys) RekeyVerificationStatus(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/verify")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -55,10 +55,10 @@ func (c *Sys) RekeyVerificationStatus() (*RekeyVerificationStatusResponse, error
 	return &result, err
 }
 
-func (c *Sys) RekeyRecoveryKeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
+func (c *Sys) RekeyRecoveryKeyVerificationStatus(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/verify")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -71,13 +71,13 @@ func (c *Sys) RekeyRecoveryKeyVerificationStatus() (*RekeyVerificationStatusResp
 	return &result, err
 }
 
-func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+func (c *Sys) RekeyInit(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -90,13 +90,13 @@ func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) 
 	return &result, err
 }
 
-func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+func (c *Sys) RekeyRecoveryKeyInit(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey-recovery-key/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -109,10 +109,10 @@ func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusRespon
 	return &result, err
 }
 
-func (c *Sys) RekeyCancel() error {
+func (c *Sys) RekeyCancel(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -121,10 +121,10 @@ func (c *Sys) RekeyCancel() error {
 	return err
 }
 
-func (c *Sys) RekeyRecoveryKeyCancel() error {
+func (c *Sys) RekeyRecoveryKeyCancel(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/init")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -133,10 +133,10 @@ func (c *Sys) RekeyRecoveryKeyCancel() error {
 	return err
 }
 
-func (c *Sys) RekeyVerificationCancel() error {
+func (c *Sys) RekeyVerificationCancel(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/verify")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -145,10 +145,10 @@ func (c *Sys) RekeyVerificationCancel() error {
 	return err
 }
 
-func (c *Sys) RekeyRecoveryKeyVerificationCancel() error {
+func (c *Sys) RekeyRecoveryKeyVerificationCancel(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/verify")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -157,7 +157,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationCancel() error {
 	return err
 }
 
-func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
+func (c *Sys) RekeyUpdate(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -168,7 +168,7 @@ func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -181,7 +181,7 @@ func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
+func (c *Sys) RekeyRecoveryKeyUpdate(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -192,7 +192,7 @@ func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse,
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -205,10 +205,10 @@ func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse,
 	return &result, err
 }
 
-func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
+func (c *Sys) RekeyRetrieveBackup(ctx context.Context) (*RekeyRetrieveResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/backup")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -233,10 +233,10 @@ func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
+func (c *Sys) RekeyRetrieveRecoveryBackup(ctx context.Context) (*RekeyRetrieveResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/recovery-backup")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -261,10 +261,10 @@ func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) RekeyDeleteBackup() error {
+func (c *Sys) RekeyDeleteBackup(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/backup")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -274,10 +274,10 @@ func (c *Sys) RekeyDeleteBackup() error {
 	return err
 }
 
-func (c *Sys) RekeyDeleteRecoveryBackup() error {
+func (c *Sys) RekeyDeleteRecoveryBackup(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/recovery-backup")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -287,7 +287,7 @@ func (c *Sys) RekeyDeleteRecoveryBackup() error {
 	return err
 }
 
-func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+func (c *Sys) RekeyVerificationUpdate(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -298,7 +298,7 @@ func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUp
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
@@ -311,7 +311,7 @@ func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUp
 	return &result, err
 }
 
-func (c *Sys) RekeyRecoveryKeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+func (c *Sys) RekeyRecoveryKeyVerificationUpdate(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -322,7 +322,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationUpdate(shard, nonce string) (*RekeyVer
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -7,10 +7,10 @@ import (
 	"time"
 )
 
-func (c *Sys) Rotate() error {
+func (c *Sys) Rotate(ctx context.Context) error {
 	r := c.c.NewRequest("POST", "/v1/sys/rotate")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -19,10 +19,10 @@ func (c *Sys) Rotate() error {
 	return err
 }
 
-func (c *Sys) KeyStatus() (*KeyStatus, error) {
+func (c *Sys) KeyStatus(ctx context.Context) (*KeyStatus, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/key-status")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -2,15 +2,15 @@ package api
 
 import "context"
 
-func (c *Sys) SealStatus() (*SealStatusResponse, error) {
+func (c *Sys) SealStatus(ctx context.Context) (*SealStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/seal-status")
-	return sealStatusRequest(c, r)
+	return sealStatusRequest(ctx, c, r)
 }
 
-func (c *Sys) Seal() error {
+func (c *Sys) Seal(ctx context.Context) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/seal")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
@@ -19,7 +19,7 @@ func (c *Sys) Seal() error {
 	return err
 }
 
-func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
+func (c *Sys) ResetUnsealProcess(ctx context.Context) (*SealStatusResponse, error) {
 	body := map[string]interface{}{"reset": true}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -27,10 +27,10 @@ func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequest(ctx, c, r)
 }
 
-func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
+func (c *Sys) Unseal(ctx context.Context, shard string) (*SealStatusResponse, error) {
 	body := map[string]interface{}{"key": shard}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -38,20 +38,20 @@ func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequest(ctx, c, r)
 }
 
-func (c *Sys) UnsealWithOptions(opts *UnsealOpts) (*SealStatusResponse, error) {
+func (c *Sys) UnsealWithOptions(ctx context.Context, opts *UnsealOpts) (*SealStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequest(ctx, c, r)
 }
 
-func sealStatusRequest(c *Sys, r *Request) (*SealStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
+func sealStatusRequest(ctx context.Context, c *Sys, r *Request) (*SealStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {

--- a/api/sys_stepdown.go
+++ b/api/sys_stepdown.go
@@ -2,10 +2,10 @@ package api
 
 import "context"
 
-func (c *Sys) StepDown() error {
+func (c *Sys) StepDown(ctx context.Context) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/step-down")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil && resp.Body != nil {


### PR DESCRIPTION
replace all patterns like

    func (a *API) Method() {
        ctx, cancelFunc := context.WithCancel(context.Background())
    }

with

    func (a *API) Method(ctx context.Context) {
        ctx, cancelFunc := context.WithCancel(ctx)
    }

so that we can use decorated context values for things like http
tracing.